### PR TITLE
remove unused config vars

### DIFF
--- a/backend/src/shared/configs/configuration-factory.ts
+++ b/backend/src/shared/configs/configuration-factory.ts
@@ -1,37 +1,6 @@
 export const configurationFactory = () => {
-  // Default postgres values
-  let postgresUser = "postgres";
-  let postgresPassword = "postgres";
-  let postgresHost = "localhost";
-  let postgresPort = 5432;
-  let postgresDb = "backenddb";
-
-  // If DATABASE_URL is set, use it to override the default postgres values
-  if (process.env.DATABASE_URL) {
-    const postgresParts = process.env.DATABASE_URL?.split("://")[1].split(":");
-    postgresUser = postgresParts[0];
-    postgresPassword = postgresParts[1].split("@")[0];
-    postgresHost = postgresParts[1].split("@")[1];
-    postgresPort = +postgresParts[2].split("/")[0];
-    postgresDb = postgresParts[2].split("/")[1].split("?")[0];
-  }
-
   return {
     nodeEnv: process.env.NODE_ENV || "development",
-
-    database: {
-      dialect: "postgres",
-      username: postgresUser,
-      password: postgresPassword,
-      host: postgresHost,
-      port: postgresPort,
-      database: postgresDb,
-      logging: process.env.SQL_LOGGING === "true",
-      define: {
-        underscored: true,
-        freezeTableName: true,
-      },
-    },
 
     appPort: +(process.env.APP_PORT || 3000),
     logLvl: process.env.LOG_LVL || "error",


### PR DESCRIPTION
Removes unused database config variables that were not being used by the app and were not being parsed correctly and missing a database