### PR TITLE
removes query flicker

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -22,7 +22,6 @@ export default function RootLayout({
 }) {
   const path = usePathname();
   const clerkPubKey = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY;
-  const orgId = process.env.NEXT_PUBLIC_ORGANIZATION_ID;
   const isUsingAuth: boolean = process.env.NEXT_PUBLIC_USE_AUTH === "true";
   const [darkMode, setDarkMode] = useDarkMode();
   // const [isCollapseNavMenu, setIsCollapseNavMenu] = useState<boolean>(false);

--- a/frontend/src/data/use-user-query.ts
+++ b/frontend/src/data/use-user-query.ts
@@ -49,9 +49,15 @@ export const useCreateUserQuery = () => {
 };
 
 export const useUserQueryResults = (queryId: string, sql?: string) => {
-  const { data, error, isLoading } = useSWR<any>(sql, () => {
-    return backendGet(`/user-queries/${queryId}/run`);
-  });
+  const { data, error, isLoading } = useSWR<any>(
+    sql,
+    () => {
+      return backendGet(`/user-queries/${queryId}/run`);
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  );
 
   return { data, error, isLoading };
 };


### PR DESCRIPTION
Removes the query flicker caused by the swr hook re-firing on focus in a way that will cause more queries to be run than needed. The user is responsible for triggering additional queries after the initial load of the query page.