### PR TITLE
BRU-1075 Create new query causing request error

### DIFF
--- a/frontend/src/app/navigation-bar.tsx
+++ b/frontend/src/app/navigation-bar.tsx
@@ -58,7 +58,7 @@ export default function NavigationBar({}) {
     router.push(`/${id}`);
   };
   const { trigger: triggerNewQuery, isMutating: isLoadingNewQuery } =
-    useCreateUserQuery();
+    useCreateUserQuery(selectedDatabase.id);
 
   const handleNewQuery = async () => {
     const newUserQuery = await triggerNewQuery();

--- a/frontend/src/data/use-user-query.ts
+++ b/frontend/src/data/use-user-query.ts
@@ -33,9 +33,8 @@ export const useUserQueries = (databaseId: string) => {
   return { data, error, isLoading };
 };
 
-export const useCreateUserQuery = () => {
+export const useCreateUserQuery = (databaseId: string) => {
   const { mutate } = useSWRConfig();
-  const [selectedDatabase] = useSelectedDatabase();
   const { data, error, trigger, isMutating } = useSWRMutation(
     "/user-queries",
     async (url: string): Promise<UserQuery> => {
@@ -45,11 +44,12 @@ export const useCreateUserQuery = () => {
         scope: "private",
         sql: "",
         type: "sql",
-        database_id: selectedDatabase.id,
+        database_id: databaseId,
         permissions: {},
         favorited_by: [],
       });
 
+      mutate(`/user-queries/db/${databaseId}`);
       mutate(`/user-queries`, createUserQueryResponse, {
         populateCache: (
           result: UserQuery,


### PR DESCRIPTION
### What this PR does
Fix the bug: Occasionally, attempting to create a new query will cause the POST request to /user-queries to error. The backend shows that the databse_id on CreateUserQueryDto is undefined, even though a database has been selected in the frontend.