### PR TITLE
Move the schema field from database to table model

### DIFF
--- a/backend/prisma/migrations/20240410213618_move_schema_from_db_to_table/migration.sql
+++ b/backend/prisma/migrations/20240410213618_move_schema_from_db_to_table/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `schema` on the `database` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "database" DROP COLUMN "schema";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,7 +14,6 @@ model database {
     external_name     String
     connection_url    String
     encryption_vector String
-    schema            String
     organization_id   String
     require_ssl       Boolean
     tables            table[]

--- a/backend/src/databases/databases.service.ts
+++ b/backend/src/databases/databases.service.ts
@@ -111,23 +111,12 @@ export class DatabasesService {
       data: {
         name: createDatabaseObj.name,
         external_name: externalName,
-        schema: createDatabaseObj.schema ?? "public",
         require_ssl: createDatabaseObj.require_ssl,
         connection_url: cypherText,
         encryption_vector: encryptionVector,
         organization_id: orgId,
       },
     });
-
-    // Get current schemas and assign default schema for database
-    const schemas = await this.findAllSchemas(database.id);
-
-    if (schemas.length > 0) {
-      const defaultSchema = schemas.includes("public") ? "public" : schemas[0];
-      await this.updateDatabase(database.id, {
-        schema: defaultSchema,
-      });
-    }
 
     assert(database, "Database creation error");
 

--- a/backend/src/definitions/database.ts
+++ b/backend/src/definitions/database.ts
@@ -7,7 +7,6 @@ export const DatabaseSchema = z.object({
   connection_url: z.string(),
   encryption_vector: z.string(),
   organization_id: z.string(),
-  schema: z.string(),
   require_ssl: z.boolean(),
   created_at: z.date(),
   updated_at: z.date(),

--- a/backend/src/user-queries/query-parsing/parse-aggregate.ts
+++ b/backend/src/user-queries/query-parsing/parse-aggregate.ts
@@ -1,7 +1,6 @@
 import { AggregateStep, Table } from "@/definitions";
-import { compileTemplate } from "./utils";
+import { compileTemplate, generateColumnName } from "./utils";
 import * as _ from "lodash";
-import * as assert from "assert";
 
 const aggregateTemplateGrouped = `
 let {{ stepName }} = (
@@ -26,60 +25,30 @@ export function parseAggregate(
   index: number,
   tables: Table[],
 ): string {
-  // Find the table for the column that the aggregate is being performed on
-  const aggregateTable = _.find(
-    tables,
-    (table) => table.id === aggregateStep.column.table,
-  );
-  assert(aggregateTable, `Table not found: ${aggregateStep.column.table}`);
+  const aggregateName = generateColumnName(aggregateStep.column, tables);
 
-  // Prefix the aggregate column with the relation name if it exists
-  let aggregatePrefix;
-  if (aggregateStep.column.relation) {
-    aggregatePrefix = aggregateStep.column.relation.as;
-  } else {
-    aggregatePrefix = aggregateTable.external_name;
-  }
-
-  let aggregatePrql = "";
   if (aggregateStep.group.length === 0) {
     // Aggregate over the whole table
-    aggregatePrql = compileTemplate(aggregateTemplateUngrouped, {
+    return compileTemplate(aggregateTemplateUngrouped, {
       stepName: `step_${index}`,
       from: `step_${index - 1}`,
       as: aggregateStep.as,
       operation: aggregateStep.operation,
-      column: `${aggregatePrefix}__${aggregateStep.column.name}`,
+      column: aggregateName,
     });
   } else {
     // Aggregate over a group
-    const groupedColumnNames = _.map(aggregateStep.group, (column) => {
-      // If the column was created via aggregate, we don't need to prefix it
-      if (column.table === "aggregate") {
-        return column.name;
-      }
+    const groupedColumnNames = _.map(aggregateStep.group, (column) =>
+      generateColumnName(column, tables),
+    );
 
-      // If the column was added via relation, prefix it with the relation name
-      if (column.relation) {
-        return `${column.relation.as}__${column.name}`;
-      }
-
-      // Otherwise, prefix it with its base table name
-      const table = _.find(tables, (table) => table.id === column.table);
-      assert(table, `Table not found: ${column.table}`);
-
-      return `${table.external_name}__${column.name}`;
-    });
-
-    aggregatePrql = compileTemplate(aggregateTemplateGrouped, {
+    return compileTemplate(aggregateTemplateGrouped, {
       stepName: `step_${index}`,
       from: `step_${index - 1}`,
       group: groupedColumnNames.join(", "),
       as: aggregateStep.as,
       operation: aggregateStep.operation,
-      column: `${aggregatePrefix}__${aggregateStep.column.name}`,
+      column: aggregateName,
     });
   }
-
-  return aggregatePrql;
 }

--- a/backend/src/user-queries/query-parsing/parse-order.ts
+++ b/backend/src/user-queries/query-parsing/parse-order.ts
@@ -1,7 +1,6 @@
 import { OrderStep, Table } from "@/definitions";
-import { compileTemplate } from "./utils";
+import { compileTemplate, generateColumnName } from "./utils";
 import * as _ from "lodash";
-import * as assert from "assert";
 
 const orderTemplate = `
 let {{ stepName }} = (
@@ -19,26 +18,8 @@ export function parseOrder(
     from: `step_${index - 1}`,
     order: _.map(orderStep.order, (singleOrder) => {
       const dir = singleOrder.direction === "asc" ? "+" : "-";
-
-      // If the ordered column was created via aggregate, we don't need to prefix it
-      if (singleOrder.column.table === "aggregate") {
-        return `${dir}${singleOrder.column.name}`;
-      }
-
-      // If the ordered column was added via relation, prefix it with the relation name
-      if (singleOrder.column.relation) {
-        return `${dir}${singleOrder.column.relation.as}__${singleOrder.column.name}`;
-      }
-
-      // Otherwise, prefix it with its base table name
-      const table = _.find(
-        tables,
-        (table) => table.id === singleOrder.column.table,
-      );
-      assert(table, `Table not found: ${singleOrder.column.table}`);
-
-      // TODO include schema?
-      return `${dir}${table.external_name}__${singleOrder.column.name}`;
+      const columnName = generateColumnName(singleOrder.column, tables);
+      return `${dir}${columnName}`;
     }).join(", "),
   });
 

--- a/backend/src/user-queries/query-parsing/parse-query.ts
+++ b/backend/src/user-queries/query-parsing/parse-query.ts
@@ -19,7 +19,7 @@ function objectToPrql(
   pipeline: Pipeline,
   tables: Table[],
   relations: Relation[],
-  tablesSchema: Record<string, Record<string, ExternalColumn>>,
+  tablesSchema: Record<string, Record<string, Record<string, ExternalColumn>>>,
 ): string {
   let prql = "prql target:sql.postgres\n";
   prql += parseFrom(pipeline.from, tables, tablesSchema);
@@ -57,7 +57,7 @@ export function writeSQL(
   pipeline: Pipeline,
   tables: Table[],
   relations: Relation[],
-  tablesSchema: Record<string, Record<string, ExternalColumn>>,
+  tablesSchema: Record<string, Record<string, Record<string, ExternalColumn>>>,
 ) {
   const prqlQuery = objectToPrql(pipeline, tables, relations, tablesSchema);
 

--- a/backend/src/user-queries/query-parsing/utils.ts
+++ b/backend/src/user-queries/query-parsing/utils.ts
@@ -1,4 +1,6 @@
+import { InferredSchemaColumn, Table } from "@/definitions";
 import * as _ from "lodash";
+import * as assert from "assert";
 
 export const baseObjectTemplate = `
 let {{ varName }} = (
@@ -11,10 +13,31 @@ let {{ varName }} = (
   }
 )`;
 
-export const compileTemplate = (template: string, data: object) => {
+export function compileTemplate(template: string, data: object): string {
   const templateOptions = {
     interpolate: /{{([\s\S]+?)}}/g, // This regex matches '{{ variableName }}'
   };
   const compiledTemplate = _.template(template, templateOptions)(data);
   return compiledTemplate;
-};
+}
+
+export function generateColumnName(
+  column: InferredSchemaColumn,
+  tables: Table[],
+): string {
+  // If the column was created via aggregate, we don't need to prefix it
+  if (column.table === "aggregate") {
+    return column.name;
+  }
+
+  // If the column was added via relation, prefix it with the relation name
+  if (column.relation) {
+    return `${column.relation.as}__${column.name}`;
+  }
+
+  // Otherwise, prefix it with its base table name
+  const table = _.find(tables, (table) => table.id === column.table);
+  assert(table, `Table not found: ${column.table}`);
+
+  return `${table.external_name}__${column.name}`;
+}

--- a/frontend/src/app/databases/database-selector.tsx
+++ b/frontend/src/app/databases/database-selector.tsx
@@ -32,16 +32,6 @@ const DatabaseSelector = ({
     setSelectedSchema(undefined);
   }, [selectedDatabase]);
 
-  const handleUpdateDatabaseSchema = async (schema: string) => {
-    await updateDatabase({
-      schema: schema,
-    });
-    setSelectedSchema(schema);
-    setSelectedDatabase({ ...selectedDatabase, schema: schema });
-
-    router.push("/");
-  };
-
   const router = useRouter();
   if (isLoadingDatabases || !databases) {
     return <MenuItem text="loading databases" className="bp5-skeleton" />;
@@ -103,7 +93,7 @@ const DatabaseSelector = ({
               key={schema}
               text={schema}
               roleStructure="listoption"
-              onClick={() => handleUpdateDatabaseSchema(schema)}
+              onClick={() => setSelectedSchema(schema)}
               selected={selectedSchema === schema}
             />
           ))}

--- a/frontend/src/components/query/query-builder/steps/from-step.tsx
+++ b/frontend/src/components/query/query-builder/steps/from-step.tsx
@@ -20,6 +20,7 @@ import { NewStepSelection } from "../query-builder";
 import { useTables } from "@/data/use-tables";
 import { useSelectedDatabase } from "@/stores";
 import { useEffect, useState } from "react";
+import * as _ from "lodash";
 
 interface FromStepProps {
   pipeline: Pipeline;
@@ -82,6 +83,10 @@ export default function FromStepComponent({
     }
   }
 
+  function filterTable(query: string, table: HydratedTable) {
+    return _.includes(table.name.toLowerCase(), query.toLowerCase());
+  }
+
   function renderContent() {
     if (isLoadingTables) {
       return <Loading />;
@@ -97,6 +102,7 @@ export default function FromStepComponent({
               items={tables!}
               itemRenderer={renderTable}
               onItemSelect={selectTable}
+              itemPredicate={filterTable}
             >
               <Button
                 rightIcon="double-caret-vertical"

--- a/frontend/src/data/use-user-query.ts
+++ b/frontend/src/data/use-user-query.ts
@@ -77,9 +77,9 @@ export const useUserQueryResults = (
   }
   const paramsString = new URLSearchParams(reducedParams).toString();
   const { data, error, trigger, isMutating } = useSWRMutation<any>(
-    sql + paramsString,
-    () => {
-      return backendGet(`/user-queries/${queryId}/run?${paramsString}`);
+    `/user-queries/${queryId}/run`,
+    async (url: string) => {
+      return await backendGet(`${url}?${paramsString}`);
     },
   );
 

--- a/frontend/src/definitions/database.ts
+++ b/frontend/src/definitions/database.ts
@@ -7,7 +7,6 @@ export const DatabaseSchema = z.object({
   connection_url: z.string(),
   encryption_vector: z.string(),
   organization_id: z.string(),
-  schema: z.string(),
   require_ssl: z.boolean(),
   created_at: z.date(),
   updated_at: z.date(),


### PR DESCRIPTION
Moves the schema field from the database model to the table model, enabling cross-schema queries.

The database will need to be migrated to update to the new version with the schema removed.