### PR TITLE
BRU-1074 Fix Blueprint Section Right Elements cut off

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -58,6 +58,9 @@ input:focus {
 .bp5-section-header-left,
 .bp5-section-header-right {
   white-space: nowrap;
-  overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.bp5-section-header-left {
+  overflow: hidden;
 }


### PR DESCRIPTION
### What this PR does
Solve the problem that section titles should be truncated or wrapped if they are longer than the available width; however the right elements should never be truncated or cut off.

### Video
[[Loom link here](https://www.loom.com/share/cc1c1901c16846c49839643ee1aac612?sid=b3df225c-7c04-4222-8f02-efad5cd4f917)]
